### PR TITLE
More retrieving all objects fixes, restore now shows 31 backups, added zip support

### DIFF
--- a/src/Form/S3ContentsForm.php
+++ b/src/Form/S3ContentsForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Aws\S3\S3Client;
 use Aws\S3\Exception\S3Exception;
+use stdClass;
 
 class S3ContentsForm extends FormBase {
 


### PR DESCRIPTION
The changes in this commit include:

- Now always retrieves all S3 bucket objects.
- Restore now displays most recent 31 backups instead of just 10. This is useful, especially when doing development of the backup system and the last good backup no longer makes it onto the list.
- Added support for ZIP files in addition to tar+gz.
- Download file content type is now application/octet-stream (generic binary) instead of just gzip.

As usual, please test before merging into the master branch as these changes have not been tested on a Drupal site.